### PR TITLE
ssl hs lavel

### DIFF
--- a/src/core/credentials/transport/ssl/ssl_credentials.cc
+++ b/src/core/credentials/transport/ssl/ssl_credentials.cc
@@ -278,8 +278,8 @@ grpc_ssl_server_credentials::~grpc_ssl_server_credentials() {
 }
 grpc_core::RefCountedPtr<grpc_server_security_connector>
 grpc_ssl_server_credentials::create_security_connector(
-    const grpc_core::ChannelArgs& /* args */) {
-  return grpc_ssl_server_security_connector_create(this->Ref());
+    const grpc_core::ChannelArgs& args) {
+  return grpc_ssl_server_security_connector_create(this->Ref(), args);
 }
 
 grpc_core::UniqueTypeName grpc_ssl_server_credentials::Type() {

--- a/src/core/credentials/transport/ssl/ssl_security_connector.cc
+++ b/src/core/credentials/transport/ssl/ssl_security_connector.cc
@@ -108,7 +108,8 @@ class grpc_ssl_channel_security_connector final
         overridden_target_name_.empty() ? target_name_.c_str()
                                         : overridden_target_name_.c_str(),
         /*network_bio_buf_size=*/0,
-        /*ssl_bio_buf_size=*/0, &tsi_hs);
+        /*ssl_bio_buf_size=*/0,
+        args.GetOwnedString(GRPC_ARG_TRANSPORT_PROTOCOLS), &tsi_hs);
     if (result != TSI_OK) {
       LOG(ERROR) << "Handshaker creation failed with error "
                  << tsi_result_to_string(result);
@@ -249,7 +250,8 @@ class grpc_ssl_server_security_connector
     tsi_handshaker* tsi_hs = nullptr;
     tsi_result result = tsi_ssl_server_handshaker_factory_create_handshaker(
         server_handshaker_factory_, /*network_bio_buf_size=*/0,
-        /*ssl_bio_buf_size=*/0, &tsi_hs);
+        /*ssl_bio_buf_size=*/0,
+        args.GetOwnedString(GRPC_ARG_TRANSPORT_PROTOCOLS), &tsi_hs);
     if (result != TSI_OK) {
       LOG(ERROR) << "Handshaker creation failed with error "
                  << tsi_result_to_string(result);

--- a/src/core/credentials/transport/ssl/ssl_security_connector.cc
+++ b/src/core/credentials/transport/ssl/ssl_security_connector.cc
@@ -199,7 +199,24 @@ class grpc_ssl_server_security_connector
     return server_handshaker_factory_;
   }
 
-  grpc_security_status InitializeHandshakerFactory() {
+  // Helper method to initialize the handshaker factory for all handshaker on
+  // the server side.
+  // - alpn_preferred_protocol_raw_list: an optional string that represents the
+  // comma-separated ordered list of preferred protocols for alpn negotiation on
+  // this server.
+  //
+  // For the server handshaker, override the preferred protocols given
+  // by the channel args on the handshaker factory creation. Do this for all
+  // handhsake that a server may producebecause it is unlikely that a server
+  // handshaker would change protocol list per handshake.
+  //
+  // OpenSSL's provided method to override the selection of the handshaker
+  // protocols for alpn is only available per context base which makes it
+  // thread-unsafe. The introduction of a lock in the server callback may make
+  // the alternative thread-safe, however it will introduce too much contention
+  // which in turn will affect performance.
+  grpc_security_status InitializeHandshakerFactory(
+      std::optional<std::string> alpn_preferred_protocol_raw_list) {
     if (has_cert_config_fetcher()) {
       // Load initial credentials from certificate_config_fetcher:
       if (!try_fetch_ssl_server_credentials()) {
@@ -210,8 +227,17 @@ class grpc_ssl_server_security_connector
       auto* server_credentials =
           static_cast<const grpc_ssl_server_credentials*>(server_creds());
       size_t num_alpn_protocols = 0;
-      const char** alpn_protocol_strings =
-          grpc_fill_alpn_protocol_strings(&num_alpn_protocols);
+      const char** alpn_protocol_strings = nullptr;
+#if TSI_OPENSSL_ALPN_SUPPORT
+      if (alpn_preferred_protocol_raw_list.has_value()) {
+        alpn_protocol_strings = ParseALPNStringIntoArray(
+            alpn_preferred_protocol_raw_list.value(), &num_alpn_protocols);
+      }
+#endif  // TSI_OPENSSL_ALPN_SUPPORT
+      if (alpn_protocol_strings == nullptr) {
+        alpn_protocol_strings =
+            grpc_fill_alpn_protocol_strings(&num_alpn_protocols);
+      }
       tsi_ssl_server_handshaker_options options;
       options.pem_key_cert_pairs =
           server_credentials->config().pem_key_cert_pairs;
@@ -250,8 +276,7 @@ class grpc_ssl_server_security_connector
     tsi_handshaker* tsi_hs = nullptr;
     tsi_result result = tsi_ssl_server_handshaker_factory_create_handshaker(
         server_handshaker_factory_, /*network_bio_buf_size=*/0,
-        /*ssl_bio_buf_size=*/0,
-        args.GetOwnedString(GRPC_ARG_TRANSPORT_PROTOCOLS), &tsi_hs);
+        /*ssl_bio_buf_size=*/0, &tsi_hs);
     if (result != TSI_OK) {
       LOG(ERROR) << "Handshaker creation failed with error "
                  << tsi_result_to_string(result);
@@ -279,9 +304,10 @@ class grpc_ssl_server_security_connector
   }
 
  private:
-  // Attempts to fetch the server certificate config if a callback is available.
-  // Current certificate config will continue to be used if the callback returns
-  // an error. Returns true if new credentials were successfully loaded.
+  // Attempts to fetch the server certificate config if a callback is
+  // available. Current certificate config will continue to be used if the
+  // callback returns an error. Returns true if new credentials were
+  // successfully loaded.
   bool try_fetch_ssl_server_credentials() {
     grpc_ssl_server_certificate_config* certificate_config = nullptr;
     bool status;
@@ -309,8 +335,8 @@ class grpc_ssl_server_security_connector
     return status;
   }
 
-  // Attempts to replace the server_handshaker_factory with a new factory using
-  // the provided grpc_ssl_server_certificate_config. Should new factory
+  // Attempts to replace the server_handshaker_factory with a new factory
+  // using the provided grpc_ssl_server_certificate_config. Should new factory
   // creation fail, the existing factory will not be replaced. Returns true on
   // success (new factory created).
   bool try_replace_server_handshaker_factory(
@@ -392,12 +418,14 @@ grpc_ssl_channel_security_connector_create(
 
 grpc_core::RefCountedPtr<grpc_server_security_connector>
 grpc_ssl_server_security_connector_create(
-    grpc_core::RefCountedPtr<grpc_server_credentials> server_credentials) {
+    grpc_core::RefCountedPtr<grpc_server_credentials> server_credentials,
+    const grpc_core::ChannelArgs& args) {
   CHECK(server_credentials != nullptr);
   grpc_core::RefCountedPtr<grpc_ssl_server_security_connector> c =
       grpc_core::MakeRefCounted<grpc_ssl_server_security_connector>(
           std::move(server_credentials));
-  const grpc_security_status retval = c->InitializeHandshakerFactory();
+  const grpc_security_status retval = c->InitializeHandshakerFactory(
+      args.GetOwnedString(GRPC_ARG_TRANSPORT_PROTOCOLS));
   if (retval != GRPC_SECURITY_OK) {
     return nullptr;
   }

--- a/src/core/credentials/transport/ssl/ssl_security_connector.cc
+++ b/src/core/credentials/transport/ssl/ssl_security_connector.cc
@@ -207,7 +207,7 @@ class grpc_ssl_server_security_connector
   //
   // For the server handshaker, override the preferred protocols given
   // by the channel args on the handshaker factory creation. Do this for all
-  // handhsake that a server may producebecause it is unlikely that a server
+  // handshake that a server may produce because it is unlikely that a server
   // handshaker would change protocol list per handshake.
   //
   // OpenSSL's provided method to override the selection of the handshaker
@@ -230,7 +230,7 @@ class grpc_ssl_server_security_connector
       const char** alpn_protocol_strings = nullptr;
       if (alpn_preferred_protocol_raw_list.has_value()) {
 #if TSI_OPENSSL_ALPN_SUPPORT
-        alpn_protocol_strings = ParseALPNStringIntoArray(
+        alpn_protocol_strings = ParseAlpnStringIntoArray(
             alpn_preferred_protocol_raw_list.value(), &num_alpn_protocols);
 #endif  // TSI_OPENSSL_ALPN_SUPPORT
       }

--- a/src/core/credentials/transport/ssl/ssl_security_connector.cc
+++ b/src/core/credentials/transport/ssl/ssl_security_connector.cc
@@ -228,12 +228,12 @@ class grpc_ssl_server_security_connector
           static_cast<const grpc_ssl_server_credentials*>(server_creds());
       size_t num_alpn_protocols = 0;
       const char** alpn_protocol_strings = nullptr;
-#if TSI_OPENSSL_ALPN_SUPPORT
       if (alpn_preferred_protocol_raw_list.has_value()) {
+#if TSI_OPENSSL_ALPN_SUPPORT
         alpn_protocol_strings = ParseALPNStringIntoArray(
             alpn_preferred_protocol_raw_list.value(), &num_alpn_protocols);
-      }
 #endif  // TSI_OPENSSL_ALPN_SUPPORT
+      }
       if (alpn_protocol_strings == nullptr) {
         alpn_protocol_strings =
             grpc_fill_alpn_protocol_strings(&num_alpn_protocols);

--- a/src/core/credentials/transport/ssl/ssl_security_connector.h
+++ b/src/core/credentials/transport/ssl/ssl_security_connector.h
@@ -76,6 +76,7 @@ struct grpc_ssl_server_config {
 //
 grpc_core::RefCountedPtr<grpc_server_security_connector>
 grpc_ssl_server_security_connector_create(
-    grpc_core::RefCountedPtr<grpc_server_credentials> server_credentials);
+    grpc_core::RefCountedPtr<grpc_server_credentials> server_credentials,
+    const grpc_core::ChannelArgs& args);
 
 #endif  // GRPC_SRC_CORE_CREDENTIALS_TRANSPORT_SSL_SSL_SECURITY_CONNECTOR_H

--- a/src/core/credentials/transport/tls/ssl_utils.cc
+++ b/src/core/credentials/transport/tls/ssl_utils.cc
@@ -200,7 +200,7 @@ const char** grpc_fill_alpn_protocol_strings(size_t* num_alpn_protocols) {
   return alpn_protocol_strings;
 }
 
-const char** ParseALPNStringIntoArray(std::string preferred_protocols_raw,
+const char** ParseAlpnStringIntoArray(absl::string_view preferred_protocols_raw,
                                       size_t* num_alpn_protocols) {
   CHECK_NE(num_alpn_protocols, nullptr);
   std::vector<std::string> preferred_protocols;

--- a/src/core/credentials/transport/tls/ssl_utils.cc
+++ b/src/core/credentials/transport/tls/ssl_utils.cc
@@ -200,6 +200,24 @@ const char** grpc_fill_alpn_protocol_strings(size_t* num_alpn_protocols) {
   return alpn_protocol_strings;
 }
 
+const char** ParseALPNStringIntoArray(std::string preferred_protocols_raw,
+                                      size_t* num_alpn_protocols) {
+  CHECK_NE(num_alpn_protocols, nullptr);
+  std::vector<std::string> preferred_protocols;
+  preferred_protocols =
+      absl::StrSplit(preferred_protocols_raw, ',', absl::SkipWhitespace());
+  *num_alpn_protocols = preferred_protocols.size();
+  const char** alpn_protocol_strings = nullptr;
+  if (*num_alpn_protocols != 0) {
+    alpn_protocol_strings = static_cast<const char**>(
+        gpr_malloc(sizeof(const char*) * (*num_alpn_protocols)));
+    for (size_t i = 0; i < *num_alpn_protocols; i++) {
+      alpn_protocol_strings[i] = gpr_strdup(preferred_protocols[i].c_str());
+    }
+  }
+  return alpn_protocol_strings;
+}
+
 int grpc_ssl_host_matches_name(const tsi_peer* peer,
                                absl::string_view peer_name) {
   absl::string_view allocated_name;

--- a/src/core/credentials/transport/tls/ssl_utils.h
+++ b/src/core/credentials/transport/tls/ssl_utils.h
@@ -77,6 +77,11 @@ tsi_tls_version grpc_get_tsi_tls_version(grpc_tls_version tls_version);
 // Return an array of strings containing alpn protocols.
 const char** grpc_fill_alpn_protocol_strings(size_t* num_alpn_protocols);
 
+// Parse a list of comma-separated protocol names into a const char** struct
+// that can be injected into the handshaker factory options.
+const char** ParseALPNStringIntoArray(std::string preferred_protocols,
+                                      size_t* num_alpn_protocols);
+
 // Initialize TSI SSL server/client handshaker factory.
 grpc_security_status grpc_ssl_tsi_client_handshaker_factory_init(
     tsi_ssl_pem_key_cert_pair* key_cert_pair, const char* pem_root_certs,

--- a/src/core/credentials/transport/tls/ssl_utils.h
+++ b/src/core/credentials/transport/tls/ssl_utils.h
@@ -79,7 +79,7 @@ const char** grpc_fill_alpn_protocol_strings(size_t* num_alpn_protocols);
 
 // Parse a list of comma-separated protocol names into a const char** struct
 // that can be injected into the handshaker factory options.
-const char** ParseALPNStringIntoArray(std::string preferred_protocols,
+const char** ParseAlpnStringIntoArray(absl::string_view preferred_protocols,
                                       size_t* num_alpn_protocols);
 
 // Initialize TSI SSL server/client handshaker factory.

--- a/src/core/credentials/transport/tls/tls_security_connector.cc
+++ b/src/core/credentials/transport/tls/tls_security_connector.cc
@@ -347,7 +347,8 @@ void TlsChannelSecurityConnector::add_handshakers(
         overridden_target_name_.empty() ? target_name_.c_str()
                                         : overridden_target_name_.c_str(),
         /*network_bio_buf_size=*/0,
-        /*ssl_bio_buf_size=*/0, &tsi_hs);
+        /*ssl_bio_buf_size=*/0, /*alpn_preferred_protocol_list=*/std::nullopt,
+        &tsi_hs);
     if (result != TSI_OK) {
       LOG(ERROR) << "Handshaker creation failed with error "
                  << tsi_result_to_string(result);
@@ -621,7 +622,8 @@ void TlsServerSecurityConnector::add_handshakers(
     // Instantiate TSI handshaker.
     tsi_result result = tsi_ssl_server_handshaker_factory_create_handshaker(
         server_handshaker_factory_, /*network_bio_buf_size=*/0,
-        /*ssl_bio_buf_size=*/0, &tsi_hs);
+        /*ssl_bio_buf_size=*/0, /*alpn_preferred_protocol_list=*/std::nullopt,
+        &tsi_hs);
     if (result != TSI_OK) {
       LOG(ERROR) << "Handshaker creation failed with error "
                  << tsi_result_to_string(result);

--- a/src/core/credentials/transport/tls/tls_security_connector.cc
+++ b/src/core/credentials/transport/tls/tls_security_connector.cc
@@ -622,8 +622,7 @@ void TlsServerSecurityConnector::add_handshakers(
     // Instantiate TSI handshaker.
     tsi_result result = tsi_ssl_server_handshaker_factory_create_handshaker(
         server_handshaker_factory_, /*network_bio_buf_size=*/0,
-        /*ssl_bio_buf_size=*/0,
-        args.GetOwnedString(GRPC_ARG_TRANSPORT_PROTOCOLS), &tsi_hs);
+        /*ssl_bio_buf_size=*/0, &tsi_hs);
     if (result != TSI_OK) {
       LOG(ERROR) << "Handshaker creation failed with error "
                  << tsi_result_to_string(result);

--- a/src/core/credentials/transport/tls/tls_security_connector.cc
+++ b/src/core/credentials/transport/tls/tls_security_connector.cc
@@ -347,8 +347,8 @@ void TlsChannelSecurityConnector::add_handshakers(
         overridden_target_name_.empty() ? target_name_.c_str()
                                         : overridden_target_name_.c_str(),
         /*network_bio_buf_size=*/0,
-        /*ssl_bio_buf_size=*/0, /*alpn_preferred_protocol_list=*/std::nullopt,
-        &tsi_hs);
+        /*ssl_bio_buf_size=*/0,
+        args.GetOwnedString(GRPC_ARG_TRANSPORT_PROTOCOLS), &tsi_hs);
     if (result != TSI_OK) {
       LOG(ERROR) << "Handshaker creation failed with error "
                  << tsi_result_to_string(result);
@@ -622,8 +622,8 @@ void TlsServerSecurityConnector::add_handshakers(
     // Instantiate TSI handshaker.
     tsi_result result = tsi_ssl_server_handshaker_factory_create_handshaker(
         server_handshaker_factory_, /*network_bio_buf_size=*/0,
-        /*ssl_bio_buf_size=*/0, /*alpn_preferred_protocol_list=*/std::nullopt,
-        &tsi_hs);
+        /*ssl_bio_buf_size=*/0,
+        args.GetOwnedString(GRPC_ARG_TRANSPORT_PROTOCOLS), &tsi_hs);
     if (result != TSI_OK) {
       LOG(ERROR) << "Handshaker creation failed with error "
                  << tsi_result_to_string(result);

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -2109,8 +2109,7 @@ static tsi_result create_tsi_ssl_handshaker(
   impl->factory_ref = tsi_ssl_handshaker_factory_ref(factory);
 #if TSI_OPENSSL_ALPN_SUPPORT
   if (alpn_preferred_protocol_raw_list.has_value() && !is_client) {
-    impl->preferred_protocol_byte_list =
-        std::move(preferred_protocol_byte_list);
+    impl->preferred_protocol_byte_list = preferred_protocol_byte_list;
     impl->preferred_protocol_byte_list_length =
         preferred_protocol_byte_list_length;
     SSL_CTX_set_alpn_select_cb(ctx, ServerHandshakerAlpnCallback, impl);

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -2008,7 +2008,7 @@ static tsi_result create_tsi_ssl_handshaker(
 #if TSI_OPENSSL_ALPN_SUPPORT
   if (alpn_preferred_protocol_raw_list.has_value()) {
     size_t num_preferred_protocols = 0;
-    const char** preferred_protocols = ParseALPNStringIntoArray(
+    const char** preferred_protocols = ParseAlpnStringIntoArray(
         alpn_preferred_protocol_raw_list.value(), &num_preferred_protocols);
     if (preferred_protocols != nullptr) {
       unsigned char* preferred_protocol_byte_list = nullptr;

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -2002,8 +2002,8 @@ static tsi_result create_tsi_ssl_handshaker(
     return TSI_OUT_OF_RESOURCES;
   }
   SSL_set_bio(ssl, ssl_io, ssl_io);
-  unsigned char* preferred_alpn_protocol_name_list;
-  size_t preferred_alpn_protocol_name_list_length;
+  unsigned char* preferred_alpn_protocol_name_list = nullptr;
+  size_t preferred_alpn_protocol_name_list_length = 0;
 #if TSI_OPENSSL_ALPN_SUPPORT
   if (alpn_preferred_protocol_list.has_value()) {
     std::vector<std::string> transport_protocols;

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -239,11 +239,17 @@ int ServerHandshakerAlpnCallback(
     const unsigned char* client_preferred_protocol_list,
     unsigned int client_preferred_protocol_list_len, void* arg) {
   tsi_ssl_handshaker* handshaker = static_cast<tsi_ssl_handshaker*>(arg);
-  return SelectProtocolList(negotiated_protocol, negotiated_protocol_len,
+
+  if (SSL_select_next_proto(const_cast<unsigned char**>(negotiated_protocol),
+                            negotiated_protocol_len,
                             client_preferred_protocol_list,
                             client_preferred_protocol_list_len,
                             handshaker->preferred_protocol_byte_list,
-                            handshaker->preferred_protocol_byte_list_length);
+                            handshaker->preferred_protocol_byte_list_length) !=
+      OPENSSL_NPN_NEGOTIATED) {
+    return SSL_TLSEXT_ERR_NOACK;
+  }
+  return SSL_TLSEXT_ERR_OK;
 }
 #endif  // TSI_OPENSSL_ALPN_SUPPORT
 }  // namespace

--- a/src/core/tsi/ssl_transport_security.h
+++ b/src/core/tsi/ssl_transport_security.h
@@ -391,9 +391,6 @@ tsi_result tsi_create_ssl_server_handshaker_factory_with_options(
 //- factory is the factory from which the handshaker will be created.
 //- network_bio_buf_size and ssl_bio_buf_size represent BIO pair buffers used in
 //  SSL. The buffer size being 0 translates to 17KB in boringSSL.
-//- alpn_preferred_protocol_list is a comma sepparated ordered list of the
-//  preferred transport protocols for this handshaker. This will override the
-//  value provided by the handshaker factory for protocol negotiation.
 //- handshaker is the address of the handshaker pointer to be created.
 
 //- This method returns TSI_OK on success or TSI_INVALID_PARAMETER in the case

--- a/src/core/tsi/ssl_transport_security.h
+++ b/src/core/tsi/ssl_transport_security.h
@@ -229,7 +229,9 @@ tsi_result tsi_create_ssl_client_handshaker_factory_with_options(
 tsi_result tsi_ssl_client_handshaker_factory_create_handshaker(
     tsi_ssl_client_handshaker_factory* factory,
     const char* server_name_indication, size_t network_bio_buf_size,
-    size_t ssl_bio_buf_size, tsi_handshaker** handshaker);
+    size_t ssl_bio_buf_size,
+    std::optional<std::string> alpn_preferred_protocol_list,
+    tsi_handshaker** handshaker);
 
 // Increments reference count of the client handshaker factory.
 tsi_ssl_client_handshaker_factory* tsi_ssl_client_handshaker_factory_ref(
@@ -392,7 +394,9 @@ tsi_result tsi_create_ssl_server_handshaker_factory_with_options(
 //  where a parameter is invalid.
 tsi_result tsi_ssl_server_handshaker_factory_create_handshaker(
     tsi_ssl_server_handshaker_factory* factory, size_t network_bio_buf_size,
-    size_t ssl_bio_buf_size, tsi_handshaker** handshaker);
+    size_t ssl_bio_buf_size,
+    std::optional<std::string> alpn_preferred_protocol_list,
+    tsi_handshaker** handshaker);
 
 // Decrements reference count of the handshaker factory. Handshaker factory will
 // be destroyed once no references exist.
@@ -413,6 +417,7 @@ int tsi_ssl_peer_matches_name(const tsi_peer* peer, absl::string_view name);
 
 // Base type of client and server handshaker factories.
 typedef struct tsi_ssl_handshaker_factory tsi_ssl_handshaker_factory;
+typedef struct tsi_ssl_handshaker tsi_ssl_handshaker;
 
 // Function pointer to handshaker_factory destructor.
 typedef void (*tsi_ssl_handshaker_factory_destructor)(

--- a/src/core/tsi/ssl_transport_security.h
+++ b/src/core/tsi/ssl_transport_security.h
@@ -222,6 +222,9 @@ tsi_result tsi_create_ssl_client_handshaker_factory_with_options(
 //  extension.
 //- network_bio_buf_size and ssl_bio_buf_size represent BIO pair buffers used in
 //  SSL. The buffer size being 0 translates to 17KB in boringSSL.
+//- alpn_preferred_protocol_list is a comma sepparated ordered list of the
+//  preferred transport protocols for this handshaker. This will override the
+//  value provided by the handshaker factory for protocol negotiation.
 //- handshaker is the address of the handshaker pointer to be created.
 
 //- This method returns TSI_OK on success or TSI_INVALID_PARAMETER in the case
@@ -388,6 +391,9 @@ tsi_result tsi_create_ssl_server_handshaker_factory_with_options(
 //- factory is the factory from which the handshaker will be created.
 //- network_bio_buf_size and ssl_bio_buf_size represent BIO pair buffers used in
 //  SSL. The buffer size being 0 translates to 17KB in boringSSL.
+//- alpn_preferred_protocol_list is a comma sepparated ordered list of the
+//  preferred transport protocols for this handshaker. This will override the
+//  value provided by the handshaker factory for protocol negotiation.
 //- handshaker is the address of the handshaker pointer to be created.
 
 //- This method returns TSI_OK on success or TSI_INVALID_PARAMETER in the case
@@ -417,7 +423,6 @@ int tsi_ssl_peer_matches_name(const tsi_peer* peer, absl::string_view name);
 
 // Base type of client and server handshaker factories.
 typedef struct tsi_ssl_handshaker_factory tsi_ssl_handshaker_factory;
-typedef struct tsi_ssl_handshaker tsi_ssl_handshaker;
 
 // Function pointer to handshaker_factory destructor.
 typedef void (*tsi_ssl_handshaker_factory_destructor)(

--- a/src/core/tsi/ssl_transport_security.h
+++ b/src/core/tsi/ssl_transport_security.h
@@ -400,9 +400,7 @@ tsi_result tsi_create_ssl_server_handshaker_factory_with_options(
 //  where a parameter is invalid.
 tsi_result tsi_ssl_server_handshaker_factory_create_handshaker(
     tsi_ssl_server_handshaker_factory* factory, size_t network_bio_buf_size,
-    size_t ssl_bio_buf_size,
-    std::optional<std::string> alpn_preferred_protocol_list,
-    tsi_handshaker** handshaker);
+    size_t ssl_bio_buf_size, tsi_handshaker** handshaker);
 
 // Decrements reference count of the handshaker factory. Handshaker factory will
 // be destroyed once no references exist.

--- a/src/core/util/http_client/httpcli_security_connector.cc
+++ b/src/core/util/http_client/httpcli_security_connector.cc
@@ -90,8 +90,8 @@ class grpc_httpcli_ssl_channel_security_connector final
     if (handshaker_factory_ != nullptr) {
       tsi_result result = tsi_ssl_client_handshaker_factory_create_handshaker(
           handshaker_factory_, secure_peer_name_, /*network_bio_buf_size=*/0,
-          /*ssl_bio_buf_size=*/0, /*alpn_preferred_protocol_list=*/std::nullopt,
-          &handshaker);
+          /*ssl_bio_buf_size=*/0,
+          args.GetOwnedString(GRPC_ARG_TRANSPORT_PROTOCOLS), &handshaker);
       if (result != TSI_OK) {
         LOG(ERROR) << "Handshaker creation failed with error "
                    << tsi_result_to_string(result);

--- a/src/core/util/http_client/httpcli_security_connector.cc
+++ b/src/core/util/http_client/httpcli_security_connector.cc
@@ -90,7 +90,8 @@ class grpc_httpcli_ssl_channel_security_connector final
     if (handshaker_factory_ != nullptr) {
       tsi_result result = tsi_ssl_client_handshaker_factory_create_handshaker(
           handshaker_factory_, secure_peer_name_, /*network_bio_buf_size=*/0,
-          /*ssl_bio_buf_size=*/0, &handshaker);
+          /*ssl_bio_buf_size=*/0, /*alpn_preferred_protocol_list=*/std::nullopt,
+          &handshaker);
       if (result != TSI_OK) {
         LOG(ERROR) << "Handshaker creation failed with error "
                    << tsi_result_to_string(result);

--- a/test/core/tsi/crl_ssl_transport_security_test.cc
+++ b/test/core/tsi/crl_ssl_transport_security_test.cc
@@ -167,10 +167,13 @@ class CrlSslTransportSecurityTest
       // Create server and client handshakers.
       EXPECT_EQ(tsi_ssl_client_handshaker_factory_create_handshaker(
                     client_handshaker_factory_, nullptr, 0, 0,
+                    /*alpn_preferred_protocol_list=*/std::nullopt,
                     &base_.client_handshaker),
                 TSI_OK);
       EXPECT_EQ(tsi_ssl_server_handshaker_factory_create_handshaker(
-                    server_handshaker_factory_, 0, 0, &base_.server_handshaker),
+                    server_handshaker_factory_, 0, 0,
+                    /*alpn_preferred_protocol_list=*/std::nullopt,
+                    &base_.server_handshaker),
                 TSI_OK);
     }
 

--- a/test/core/tsi/crl_ssl_transport_security_test.cc
+++ b/test/core/tsi/crl_ssl_transport_security_test.cc
@@ -172,7 +172,6 @@ class CrlSslTransportSecurityTest
                 TSI_OK);
       EXPECT_EQ(tsi_ssl_server_handshaker_factory_create_handshaker(
                     server_handshaker_factory_, 0, 0,
-                    /*alpn_preferred_protocol_list=*/std::nullopt,
                     &base_.server_handshaker),
                 TSI_OK);
     }

--- a/test/core/tsi/crl_ssl_transport_security_test.cc
+++ b/test/core/tsi/crl_ssl_transport_security_test.cc
@@ -171,8 +171,7 @@ class CrlSslTransportSecurityTest
                     &base_.client_handshaker),
                 TSI_OK);
       EXPECT_EQ(tsi_ssl_server_handshaker_factory_create_handshaker(
-                    server_handshaker_factory_, 0, 0,
-                    &base_.server_handshaker),
+                    server_handshaker_factory_, 0, 0, &base_.server_handshaker),
                 TSI_OK);
     }
 

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -382,7 +382,7 @@ class SslTransportSecurityTest
           alpn_lib->alpn_mode == ALPN_CLIENT_SERVER_MISMATCH) {
         if (ssl_fixture->alpn_server_overriden_protocols_.has_value()) {
           size_t num_parsed_protocols = 0;
-          server_options.alpn_protocols = ParseALPNStringIntoArray(
+          server_options.alpn_protocols = ParseAlpnStringIntoArray(
               ssl_fixture->alpn_server_overriden_protocols_.value(),
               static_cast<size_t*>(&num_parsed_protocols));
           server_options.num_alpn_protocols = num_parsed_protocols;
@@ -429,7 +429,7 @@ class SslTransportSecurityTest
                 TSI_OK);
       if (ssl_fixture->alpn_server_overriden_protocols_.has_value()) {
         // Free memory from creating the server protocol list if
-        // ParseALPNStringIntoArray was used.
+        // ParseAlpnStringIntoArray was used.
         for (size_t i = 0; i < server_options.num_alpn_protocols; i++) {
           gpr_free(const_cast<char*>(server_options.alpn_protocols[i]));
         }

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -1447,7 +1447,7 @@ TEST_P(SslTransportSecurityTest, TestClientHandshakerOverrideALPN) {
   SetUpSslFixture(/*tls_version=*/std::get<0>(GetParam()),
                   /*send_client_ca_list=*/std::get<1>(GetParam()));
   ssl_fixture_->OverrideHanshakerAlpnClientProtocols("toto,bar");
-  ssl_fixture_->OverrideHanshakerAlpnServerProtocols("bar,foo");
+  ssl_fixture_->OverrideHanshakerAlpnServerProtocols("bar,foo,toto");
   ssl_fixture_->SetAlpnMode(ALPN_CLIENT_SERVER_OK);
   DoHandshake();
 }

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -1441,9 +1441,8 @@ TEST(SslTransportSecurityTest, ExtractCertChain) {
   sk_X509_pop_free(cert_chain, X509_free);
 }
 
-// Attempt to create a handhsake between a client and a server with a protocol
-// negotiation but overriding the preferred protocols values of the handshaker
-// factory.
+// Attempt to perform a handshake between a client and server with ALPN enabled
+// and overriding the preferred protocols on the handshaker factory.
 TEST_P(SslTransportSecurityTest, TestClientHandshakerOverrideALPN) {
   SetUpSslFixture(/*tls_version=*/std::get<0>(GetParam()),
                   /*send_client_ca_list=*/std::get<1>(GetParam()));


### PR DESCRIPTION
- **[channelz] Pass correct json object to data source**
- **[event-engine] Secure Endpoint implementation (#39197)**
- **Remove `latency` parameter from `CallAttemptTracer::RecordEnd` This is not used by any implementations.**
- **[gtest] Update dependency to v1.16.0 (#39207)**
- **[doc] Add docs for connection backoff channel args (#39153)**
- **[PH2][EXPERIMENT] New experiment in Sleep  (#39146)**
- **[PH2][BUILD] Just fixing build files (#39209)**
- **[PH2][BUILD] Just build file changes. (#39200)**
- **[PH2][Trivial] Fixing initialization**
- **Fix secure endpoint**
- **[channelz] HTTP/2 ztrace facility (#39189)**
- **[test] fix windows (#39220)**
- **[OTel C++] Reorganize tests (#39215)**
- **[CI] Ruby migrate MacOS Sonoma (#39116)**
- **[Update grpc_deps.bzl] Add the yaml-cpp dependencies to external_deps (#39216)**
- **[CI] PHP build setup changes for MacOs Sonoma (#39103)**
- **[reorg] Split the transport auth_context definitions into a separate library target**
- **Add a shared bit gen class**
- **[channelz] Add channel args to channelz nodes**
- **[Filter Fusion] Promise based filter changes for filter fusion.**
- **[ztrace] Bound maximum memory usage per trace (#39211)**
- **[channelz] interface tweaks**
- **[channelz] Extension to export event engine endpoint info to channelz**
- **adding e2e test cases for GRPC_COMPRESSION_CHANNEL_DEFAULT_LEVEL (#39185)**
- **[Dep] Added a flag to build with `openssl` instead of `boringssl`. (#39188)**
- **[CI] Python migrate MacOS Sonoma (#39117)**
- **[chaotic-good] Add a context object for transport-globals (#39226)**
- **[cleanup] Remove fuzzer_asan bazel config (#39227)**
- **[server_listener] Stabilize and remove experiment (#39242)**
- **[ztrace] Limit maximum trace time, concurrency of ztraces (#39234)**
- **Fix double-reporting of data frames, bad time stamps in json**
- **[PH2][Transport][Frame] Assemble Http2DataFrame into gRPC Message (#39144)**
- **[telemetry] Move ContextList type for RPC traces out of chttp2 (#39213)**
- **[PSM Interop] Dualstack Cleanup (#39191)**
- **[PH2][Build] Painful build file changes Want to get them out of the way so that I can code in peace.**
- **[PSM Interop] fix comma in cleanup trigger (#39255)**
- **[CI] CI fixes (#39251)**
- **[cleanup] Use new `SharedBitGen` in lots of places (#39254)**
- **[build] Convert config.w32 template (#39235)**
- **[build] Convert more templates (#39236)**
- **[tests] Add a post-mortem debugging data utility (#39245)**
- **[channelz] Add channelz for the filter stack (#39250)**
- **[cleanup] SharedBitGen missed review comments (#39259)**
- **[EventEngine] Fix busy loop in thread pool when shutting down (#39258)**
- **[bloat] Add a compile time option to remove ztraces from the build (#39257)**
- **[OTel C++] Improve logging for tests (#39246)**
- **[PH2][BUILD] Build file changes (#39261)**
- **[PH2][Test] Fuzz test for message assembler (#39264)**
- **[interop] Add grpc-java 1.72.0 to client_matrix.py (#39263)**
- **Automated rollback of commit 92fb814b17a3223ace2f07c1241a8d8e17549a4e.**
- **[experiments] Bump EventEngine DNS experiment expiration dates (#39268)**
- **[event_engine] Introduce PosixEventEngine factory (#39247)**
- **grpcio-tools: add script (#39090)**
- **[ObjC] add GRPC_CFSTREAM_MAX_THREADPOOL_SIZE to limit cf event engine thread pool to size (#39042)**
- **Automated rollback of commit 20901a410204ef56fbf01bd3609546145b35772d.**
- **[experiments] Bump EventEngine non-DNS experiment expiration dates (#39269)**
- **[channelz] Allow querying sub-objects from a DataSource (#39249)**
- **[URI] fix parsing of user_info in proxy settings (#39004)**
- **[experiments] Update free_large_allocator expiration (#39273)**
- **[transport] Add hooks to choose between transports (#39252)**
- **[shared-bit-gen] Stop using inline static (#39260)**
- **Automated rollback of commit d7d6958546888bdb3303fd6d4619f4b85fd440fa.**
- **Event Engine write metrics**
- **[experiments] Update expiry of local_connector_secure experiment. (#39280)**
- **[sanity] Fix (#39282)**
- **fix: resolve issue where pre-release versions of protobuf are installed (#38986)**
- **[DNSResolver] Expose LookupHostNameBlocking in the header file**
- **Automated rollback of commit ca35be49e065de22a4a0d959ac6c00e367a3d2c8.**
- **[gRPC HTTP/2 spec] pseudo-headers must come first, as per RFC-9113 (#39279)**
- **[grpc_error] fix all tests to pass both with and without error_flatten experiment enabled (#39065)**
- **[URI] convert scheme to lower-case (#39248)**
- **[CI] Fix (#39300)**
- **[Security] Add a SPIFFE ID parser (#39148)**
- **[Filter Fusion] Create method and Fused Filter TypeName Implementation**
- **[RLS] fix use-after-free from accessing config after LB policy shutdown (#39303)**
- **[PH2][TODO] Adding the pseudocode of our desired fuzz tests (#39310)**
- **[CI] Reverting output path from RBE (#39311)**
- **[channelz] Add tracers to chaotic-good (#39233)**
- **[subchannel] Add sharding for the global address pool (#39305)**
- **[PH2][Transport][Experiment] Add an experiment to strictly enforce MaxInflightPings (#39237)**
- **[PH2][BUILD] Moving out common testing string and error codes into common files (#39309)**
- **Split CoreConfiguration builders into two buckets: ephemeral and persistent.**
- **[PH2][Build] Fix (#39325)**
- **[Sanity] Fix (#39326)**
- **[chaotic-good] Rate based load balancer (#39221)**
- **Removed no-gen2 flag to allow support for Python313 runtime (#39327)**
- **[chaotic-good] Add fathom metrics to ztrace (#39328)**
- **[channelz] Shard indices (#39306)**
- **[build] Convert more templates to inja (#39304)**
- **[CI] upgrage clang 7 to 11 (#39284)**
- **[channelz] Fix type error in ztrace (#39347)**
- **Potential fix for crash in gRPC iOS with the callback API**
- **Switch chaotic-good to new style endpoint-transport creation**
- **[json] Adjust `FromNumber` to accept any arithmetic type (#39350)**
- **[sanity] Fix (#39353)**
- **[ssl] Ensure SSL TSI's protect and unprotect methods can be called concurrently. (#39308)**
- **[tsi] Clarify thread-safety expectations on the TSI frame protectors. (#39351)**
- **[Bazel Test] Exclude `//tools/codegen/core:experiments_compiler` target from bazel test (#39337)**
- **[secure-endpoint] Add an experiment to offload immediate reads/writes to event engine (#39298)**
- **[EventEngine] Add test around errqueue support (#39338)**
- **[proxy] Fix e2e proxy fixture for trailer only responses (#39361)**
- **Remove strings from providers list**
- **[interop client] document new flag for google-c2p resolver (#38933)**
- **[channelz] Further reduce contention (#39357)**
- **[interop] Add v1.71.1, v1.72.0 release of grpc-go to interop matrix (#39352)**
- **[config] Remove old RegisterBuilder function (#39366)**
- **[channelz] List v1 channel stack filters (#39360)**
- **[chttp2] Add an experiment to bound write sizes (#39367)**
- **No public description**
- **[PH2][Ping] Initial Support (#39158)**
- **[PH2][BUILD] Changes to build files, and writing function signatures - Just a skeleton of the upcoming work (#39345)**
- **[PH2][Ping] Extra (#39377)**
- **Remove bogus debug check**
- **Protect grpc generated sources from unwanted system macros (#39266)**
- **[security] Remove lock that guards the tsi_frame_protector. (#39356)**
- **[EventEngine] Fix use-after-free in Posix native DNS resolver (#39390)**
- **Fix read data frames tracing**
- **[PH2][Http2Status][Error] Error code (#39160)**
- **[Cleanup] Add TODO around usage of absl endian utility functions**
- **[PH2][Ping] Fix test flakiness (#39397)**
- **[Bazel RBE Non-Bazel Tests] Exclude //tools/codegen/core:experiments_compiler_test (#39369)**
- **[opencensus] Reduce flakiness in tracing tests (#39393)**
- **Attach sockets to servers in v3**
- **Make trace events more useful**
- **Log server handshake failures for Chaotic-Good**
- **[secure-endpoint] Rewrite parallel write path (#39411)**
- **[PH2] Track slot usage of transport's party (#39415)**
- **[Build] Fix use_openssl=true (#39380)**
- **[build] Fix template (#39348)**
- **[ErrQueue] Fix test (#39425)**
- **[test] Add postmortem analysis to ssl_credentials_test (#39432)**
- **[http2] Disable a very flaky test (#39434)**
- **[test] Add postmortem analysis to client_lb_end2end_test (#39431)**
- **[ssl] Only run select SSL tests when built against BoringSSL. (#39433)**
- **[cleanup] localhork (#39435)**
- **Add a useful debug trace log on transport closure**
- **[qps-test] Expand by adding an option for chaotic-good (#39376)**
- **[ztrace] Add a trace flag to log all ztraces - for debugging the ztrace system (#39424)**
- **Improve chaotic-good ztraces**
- **[chaotic-good] Enable encrypted links (#39427)**
- **[chaotic-good] Tuning**
- **[channelz] Restore accidentally removed comment (#39368)**
- **[Experiment codegen tool] Enforce matching between rollout configurations and experiment definitions.**
- **Expose GRPC_OPENSSL_CLEANUP_TIMEOUT to control shutdown grace period (#39297)**
- **Fix Python 3.12 MacOS release artifact (#39418)**
- **[Experiment codegen tool] Move experiments_compiler_test.cc to new folder. (#39449)**
- **[chaotic-good] Add padding to data connection headers to ensure alignment**
- **[test] Unflake //t...c...i/backend_metrics_lb_policy_test.cc (#39459)**
- **[slice-buffer] Further reduce number of inline elements (#39460)**
- **   Implement C++ experiment compiler. This is the initial step in migrating the gRPC Experiment Framework to a C++ compiler.**
- **[tsi] Clarify concurrency expectations for TSI frame protector's protect and protect_flush methods. (#39464)**
- **[qps-worker] Enable latent-see collection (#39455)**
- **Fix races with data source shutdown**
- **[Ph2][Transport] Keep alive Support (#39232)**
- **[PH2][CHTTP2][Transport] Add an experiment to enforce keepalive timeout (#39239)**
- **Remove thread ids from traces.**
- **Automated rollback of commit b086f689effef7276bef6456f599aee1c12489d4.**
- **Add transport protocol preferences to ALTS handshake (#39204)**
- **[resource-quota] Fix potential race (#39467)**
- **[alpn] Inject ALPN Protocols from channel args**




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

