### PR TITLE
ALTS Integrity-only Negotiation

### DIFF
--- a/src/core/credentials/transport/alts/grpc_alts_credentials_client_options.cc
+++ b/src/core/credentials/transport/alts/grpc_alts_credentials_client_options.cc
@@ -21,6 +21,8 @@
 #include <grpc/support/port_platform.h>
 #include <grpc/support/string_util.h>
 
+#include <algorithm>
+#include <optional>
 #include <memory>
 
 #include "absl/log/log.h"
@@ -72,8 +74,7 @@ static const grpc_alts_credentials_options_vtable vtable = {
 
 grpc_alts_credentials_options* grpc_alts_credentials_client_options_create(
     void) {
-  auto client_options = static_cast<grpc_alts_credentials_client_options*>(
-      gpr_zalloc(sizeof(grpc_alts_credentials_client_options)));
+  auto client_options = new grpc_alts_credentials_client_options();
   client_options->base.vtable = &vtable;
   return &client_options->base;
 }
@@ -103,6 +104,9 @@ static grpc_alts_credentials_options* alts_client_options_copy(
     prev = new_node;
     node = node->next;
   }
+
+  new_options->record_protocols = options->record_protocols;
+
   new_client_options->token_fetcher =
       reinterpret_cast<const grpc_alts_credentials_client_options*>(options)
           ->token_fetcher;
@@ -135,5 +139,5 @@ static void alts_client_options_destroy(
     target_service_account_destroy(node);
     node = next_node;
   }
-  client_options->token_fetcher.reset();
+  delete client_options;
 }

--- a/src/core/credentials/transport/alts/grpc_alts_credentials_options.cc
+++ b/src/core/credentials/transport/alts/grpc_alts_credentials_options.cc
@@ -40,6 +40,5 @@ void grpc_alts_credentials_options_destroy(
     if (options->vtable != nullptr && options->vtable->destruct != nullptr) {
       options->vtable->destruct(options);
     }
-    gpr_free(options);
   }
 }

--- a/src/core/credentials/transport/alts/grpc_alts_credentials_options.h
+++ b/src/core/credentials/transport/alts/grpc_alts_credentials_options.h
@@ -25,6 +25,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "absl/status/statusor.h"
 #include "src/core/tsi/alts/handshaker/transport_security_common_api.h"
@@ -55,6 +56,7 @@ typedef struct grpc_alts_credentials_options_vtable {
 struct grpc_alts_credentials_options {
   const struct grpc_alts_credentials_options_vtable* vtable;
   grpc_gcp_rpc_protocol_versions rpc_versions;
+  std::vector<std::string> record_protocols;
 };
 
 typedef struct target_service_account {

--- a/src/core/credentials/transport/alts/grpc_alts_credentials_server_options.cc
+++ b/src/core/credentials/transport/alts/grpc_alts_credentials_server_options.cc
@@ -27,7 +27,12 @@ static grpc_alts_credentials_options* alts_server_options_copy(
     const grpc_alts_credentials_options* options);
 
 static void alts_server_options_destroy(
-    grpc_alts_credentials_options* /*options*/) {}
+    grpc_alts_credentials_options* options) {
+  if (options == nullptr) {
+    return;
+  }
+  delete reinterpret_cast<grpc_alts_credentials_server_options*>(options);
+}
 
 static const grpc_alts_credentials_options_vtable vtable = {
     alts_server_options_copy, alts_server_options_destroy};
@@ -35,8 +40,7 @@ static const grpc_alts_credentials_options_vtable vtable = {
 grpc_alts_credentials_options* grpc_alts_credentials_server_options_create(
     void) {
   grpc_alts_credentials_server_options* server_options =
-      static_cast<grpc_alts_credentials_server_options*>(
-          gpr_zalloc(sizeof(*server_options)));
+      new grpc_alts_credentials_server_options();
   server_options->base.vtable = &vtable;
   return &server_options->base;
 }
@@ -51,5 +55,6 @@ static grpc_alts_credentials_options* alts_server_options_copy(
   // Copy rpc protocol versions.
   grpc_gcp_rpc_protocol_versions_copy(&options->rpc_versions,
                                       &new_options->rpc_versions);
+  new_options->record_protocols = options->record_protocols;
   return new_options;
 }

--- a/src/core/tsi/alts/handshaker/alts_handshaker_client.cc
+++ b/src/core/tsi/alts/handshaker/alts_handshaker_client.cc
@@ -511,9 +511,17 @@ static grpc_byte_buffer* get_serialized_start_client(
   grpc_gcp_StartClientHandshakeReq_add_application_protocols(
       start_client, upb_StringView_FromString(ALTS_APPLICATION_PROTOCOL),
       arena.ptr());
-  grpc_gcp_StartClientHandshakeReq_add_record_protocols(
-      start_client, upb_StringView_FromString(ALTS_RECORD_PROTOCOL),
-      arena.ptr());
+  if (client->options->record_protocols.empty()) {
+    grpc_gcp_StartClientHandshakeReq_add_record_protocols(
+        start_client, upb_StringView_FromString(ALTS_RECORD_PROTOCOL),
+        arena.ptr());
+  } else {
+    for (const auto& record_protocol : client->options->record_protocols) {
+      grpc_gcp_StartClientHandshakeReq_add_record_protocols(
+          start_client, upb_StringView_FromString(record_protocol.c_str()),
+          arena.ptr());
+    }
+  }
   grpc_gcp_RpcProtocolVersions* client_version =
       grpc_gcp_StartClientHandshakeReq_mutable_rpc_versions(start_client,
                                                             arena.ptr());
@@ -608,8 +616,16 @@ static grpc_byte_buffer* get_serialized_start_server(
       arena.ptr());
   grpc_gcp_ServerHandshakeParameters* value =
       grpc_gcp_ServerHandshakeParameters_new(arena.ptr());
-  grpc_gcp_ServerHandshakeParameters_add_record_protocols(
-      value, upb_StringView_FromString(ALTS_RECORD_PROTOCOL), arena.ptr());
+  if (client->options->record_protocols.empty()) {
+    grpc_gcp_ServerHandshakeParameters_add_record_protocols(
+        value, upb_StringView_FromString(ALTS_RECORD_PROTOCOL), arena.ptr());
+  } else {
+    for (const auto& record_protocol : client->options->record_protocols) {
+      grpc_gcp_ServerHandshakeParameters_add_record_protocols(
+          value, upb_StringView_FromString(record_protocol.c_str()),
+          arena.ptr());
+    }
+  }
   grpc_gcp_StartServerHandshakeReq_handshake_parameters_set(
       start_server, grpc_gcp_ALTS, value, arena.ptr());
   grpc_gcp_StartServerHandshakeReq_set_in_bytes(


### PR DESCRIPTION
- **[channelz-v2] Environment state for zviz**
- **[XdsCreds] Cleanup (#40000)**
- **[SSL] Add debug log for SNI (#40001)**
- **[zviz] Layout interface**
- **[PHP] Fully qualify stdClass with global namespace (#39996)**
- **[blackboard] split state updates from filter stack construction (#39964)**
- **[zviz] Data Formatter**
- **[Ruby] Increase timeout for tests (#40011)**
- **[dep] Upgrade Protobuf Version 31.1 (#39916)**
- **[zviz] Trace Formatter**
- **[zviz] Entity Formatter**
- **[experiments] Bump EventEngine experiment expiration dates (#40003)**
- **[PH2] Add a End2End Fixture (#40019)**
- **[PH2] Basic minimal connector code (#39930)**
- **[zviz] HTML helpers**
- **[zviz] HTML Layout Engine**
- **Introduce build flags for shared bitgen**
- **[sanity] Fix (#40022)**
- **[xDS] add call creds registry and bootstrap plumbing for JWT token file call creds (#39772)**
- **[zviz] Add a test for entity -> layout -> html -> string**
- **Avoid protecting/unprotecting after secure endpoint shutdown.**
- **[build] add some visibility tags (#40025)**
- **[channelz] Add a mechanism to run the post mortem logic without logging anything**
- **[channelz] Add checks to yodel that channelz is working for the system under test**
- **[PH2] Fixing transport bugs for ping pong (#40013)**
- **[channelz] Don't register nodes until the object is fully constructed**
- **[channelz] Don't register data source until object is constructed**
- **[channelz] Remove call stack size**
- **[channelz] Fix data races in channelz/chttp2**
- **[channelz] Add checks to e2e fuzzers that channelz is working**
- **[channelz] Fix endpoint/channelz shutdown ordering**
- **[chaotic-good] Fix use-after-free (#40034)**
- **[upb] Move generation from python to c++ (#39967)**
- **[chttp2] Add clarifying comment and debugging logs on graceful_shutdown_test (#40002)**
- **[chaotic-good] Fix tsan race in channelz collection**
- **[python] Improve debugging for fork test (#39886)**
- **[channelz] Add checks to core e2e tests that channelz is working**
- **Fix int32 overflow in grpc protobuf serialization.**
- **[channelz] Add property table type to proto (#40043)**
- **Add `#include <memory>` to BoringSSL headers to make them work with Windows SDK.**
- **[channelz] make PropertyList (&co) produce both json & proto (upb) representations**
- **[channelz] Fix ref counting bug (#40045)**
- **[channelz] Always move through a property list to generate party json**
- **[channelz] Change server_transport channelz data to use channelz::PropertyList**
- **[channelz] Make raw json method for additional info private**
- **[channelz] Promise proto updates (#40048)**
- **[channelz] Latest changes to channelz.proto (#40050)**
- **[channelz] Export json & proto additional data**
- **[xDS] add per-authority knob to fallback based on reachability only (#39889)**
- **[channelz] Add a method to serialize a channelz entity to a protobuf encoded string**
- **[channelz] Add framework to convert promises to proto**
- **[channelz] Expose property lists, not json objects from mpsc**
- **[channelz] Allow `Map` to be serialized to proto**
- **[channelz] Allow `If` to be serialized to proto**
- **Allow `Loop` to be serialized in proto**
- **Allow `Race` to be serialized in proto**
- **[channelz] Fix nullptr access (#40055)**
- **[chaotic-good] Fix lock ordering bug (#40054)**
- **[party] Generalize PropertyValue extension mechanism**
- **[EventEngine] Use pollset_alternative for EnvironmentAutoDetect (#39979)**
- **Automated rollback of commit b51168534120b08d951795a6f085e043050e2e89.**
- **[EventEngine] Use pollset_alternative for HttpRequests (#39978)**
- **[channelz] Convert Promises to channelz properties rather than just JSON.**
- **Allow `Seq` to be serialized to proto**
- **[sanity] Fix (#40075)**
- **[channelz] Remove Json serialization from `If`**
- **[deps] Update absl to 20250512.1 (#39571)**
- **[CI] Fix grpc_docker_test (#40059)**
- **[windows] Fix build (#40078)**
- **[channelz] Fix ref counting bug for orphaned nodes (#40081)**
- **[channelz] Remove Json serialization from `Map`**
- **[channelz] Remove Json serialization from `Loop`**
- **[channelz] Remove Json serialization from `Race`**
- **[channelz] Remove Json from Seq**
- **[channelz] Remove Promise -> Json conversion**
- **[channelz] Cleanup channelz service: the service is never null**
- **[channelz-v2] Add service proto**
- **[channelz] Implement entity type --> kind, and back**
- **[PH2] Fix PH2 macros (#40082)**
- **[build] Fix cmake builds (#40083)**
- **[PH2] Plug OnRecvSettings (#40084)**
- **[xDS] refactor StringMatcher parsing code (#40080)**
- **[blackboard] enable on server side (#39983)**
- **[Python] CI: Speed up distribtest image builds (#39613)**
- **[PH2] Write test config for PH2 But bypass it whenever the experiment is off.**
- **[cmake] Fix build (#40089)**
- **Add move constructor to ArenaPromise vtable (#38719)**
- **[PH2] MACRO to disable PH2 to reduce binary bloating for some platforms (#40031)**
- **[Python] Upgrade Pytype (Part - 2) (#39817)**
- **[PH2] E2E (#40094)**
- **[build] Enable bazel profiling (#40090)**
- **[channelz-v2] Implement channelz-v2 service**
- **[FilterFusion] Modify ChannelInit to allow registering fused filters (#39641)**
- **[Test] Fixed unused warnings (#40103)**
- **Fix gRPC Python docs website layout - use spaces optimally (#40073)**
- **[API] add new API to create channel from fd or endpoint that supports… (#40017)**
- **[channelz] Remove unused function**
- **[PH2][EXPERIMENT] Update expiry (#40104)**
- **[PH2] Removing test skips. We found a better approach (#40108)**
- **[PH2] Just adding parameter names. Cosmetic change (#40109)**
- **[channelz] Export intrinsic data to v2**
- **[CI] Updated grpc_interop_aspnetcore docker (#40088)**
- **[Release] Bump core version to 49.0.0 for upcoming release (#40101)**
- **[Release] Bump version to 1.75.0-dev (on master branch) (#40120)**
- **[PH2] Removing incorrect config**
- **Guard `c_ares_ev_driver.h` with `GRPC_ARES` to skip unused build paths**
- **[FilterFusion] Define a build target containing fused filters and link this target into gRPC core (#39697)**
- **[ai] Create gemini guide file for the repository**
- **Add experiment to pipeline secure endpoint reads so reading and unprotecting can occur in parallel.**
- **[Python][CI] Update python versions in grpc_artifact_python images (#40102)**
- **Revert https://github.com/grpc/grpc/pull/39697 as it increase binary size of mobile builds**
- **[event_engine] Fix race conditions in the timer manager shutdown. (#40133)**
- **Fix data race by adding custom getter for `state` property with @synchronized locking. (#40146)**
- **[ServerGlobalCallbacks] Stabilize experiment (#40041)**
- **[auth] add injectable custom peer comparison fn (#39610)**
- **[PH2] Adding new file (#40149)**
- **Internal visibility changes**
- **[channelz] Generate UPB for the v1 channelz (#40126)**
- **[channelz] v2->v1: a library to convert new to old**
- **[Python] grpcio_testing: handle UnboundLocalError in a server test helper (#40140)**
- **[Ruby] Add rubygems support for linux-gnu and linux-musl platforms (#39549)**
- **[pick_first] fix bug that caused us to stop attempting to connect (#40162)**
- **[ALTS] improve alts handshaker error logs on failure to receive messages from alts handshaker (#40163)**
- **[PH2] Minor Comments (#40157)**
- **[PH2] PH2 End to end tests (#40150)**
- **[PH2] Enabling PH2 E2E tests (#40155)**
- **[Python][Part 1] - Introducing Ruff  (#40160)**
- **[Deps] Fixed BCR gtest version (#40166)**
- **[Deps] Updated third_party/protoc-gen-validate (#40167)**
- **Fix correct path for ruff.toml (#40175)**
- **[channelz] Make PropertyList deteriministically ordered (#40168)**
- **[Maintainers] Move inactive maintainers to emeritus (#40024)**
- **[Maintainers] Move Daniel Born to Emeritus Maintainer (#40036)**
- **[channelz] Ensure descriptors available for test (#40159)**
- **[PH2] Removing incorrect log Replace ERROR log with VLOG in message assembler. The case when we get incomplete message is normal and will occur frequently. We should not ERROR log for this.**
- **[PH2] Adding newly passing PH2 tests and removing 1 flake**
- **[xDS] fix typo in xds_dependency_manager (#40203)**
- **[CI] Don't tie python version in sanatise script (#40205)**
- **[PH2] Disable flaky end2end ph2 tests**
- **[CI] Bump pylint to 2.17.7 (#40169)**
- **[XdsClient] remove unnecessary build deps**
- **[PH2] Fixing circular dependency (#40204)**
- **Revert "[ServerGlobalCallbacks] Stabilize experiment (#40041)" (#40177)**
- **[channelz] v2->v1 - Convert ChannelzService to use conversion library**
- **[Build] Added missing useful to cf_event_engine (#40209)**
- **[ServerGlobalCallbacks] Experiment defaults true (#40178)**
- **Build fix**
- **[Python] [Part 1] Add Typeguard to AIO stack in tests (#40201)**
- **Reland https://github.com/grpc/grpc/pull/39697**
- **[PH2][Stream] Simple queue (#39777)**
- **[LB policy test lib] remove unnecessary synchronization (#40176)**
- **[Doc] Updated the third_party/README.md (#40218)**
- **[CI] Added check_bzl_deps.py (#40164)**
- **[channelz] Update channelz v1 to be just one proto rule**
- **[channelz] Move legacy apis to use v2->v1**
- **[Python] Remove outdated python version note from grpcio-tools README (#39313)**
- **Don't shutdown fds in c-ares resolver until all requests are complete**
- **[Python] Add typing-extensions dependency (#40137)**
- **[Etc] Changed the directory ownership (#40227)**
- **[ruby] bump timeout for ruby artifact build (#40229)**
- **[Filter Fusion] Change the names of legacy filters to avoid detecting and replacing them during the string matching process to replace individual filter chains with fused filters.**
- **[Python] GitHub templates: add untraiged label to Python bugs/features (#40225)**
- **[Python] Remove `compat_check_pypi` from grpcio README.rst (#37452)**
- **[c-ares] update version to 1.34.5 (#39508)**
- **[CI] Small change to Bazel Deps Test (#40228)**
- **[Filter Fusion] Integrate fused filters target into core gRPC (#40231)**
- **Fix bazel query //tools/distrib/python/grpcio_tools/... (#40236)**
- **[PH2] Adding RFC "MUST"s to settings frame parsing  (#40214)**
- **Fix bazel query //src/python/... (#40238)**
- **[Python] Fix for windows distribtest (#40151)**
- **[PH2] Ping bug (#40092)**
- **Rollback channelz v2tov1 related changes**
- **[useful] Add Constexpr Pow() function**
- **[Security - XDS] Add Spiffe Bundle Map support to providers (#39708)**
- **[RR & WRR] start connecting to endpoints from a random start index (#40235)**
- **Internal visibility changes**
- **Internal visibility changes**
- **[trace] Migrate trace flag generation to C++**
- **[build] add missing visibility group (#40250)**
- **BUILD file cleanup**
- **[build] Add Missing Dependencies in Preparation for Enabling layering_check**
- **[Deps] Updated Abseil for cocoapod to 1.20250512.1 (#40252)**
- **[CI] Used clang:11-bullseye for clang-11 (#40249)**
- **[CI] Mark some old docker images not buildable (#40251)**
- **Revert https://github.com/grpc/grpc/pull/40231**
- **Revert  https://github.com/grpc/grpc/pull/40179**
- **[PH2][Trivial] Adding DCHECKS**
- **[build] Exclude tools/codegen/core from bazel version tests (#40272)**
- **Automated rollback of commit 889aaeae794e3f7d8feac3f3615b388591d16dac.**
- **Update ccache version in all referencing Dockerfiles (#40264)**
- **[CI] Fix PR AutoFix GitHub action (#40257)**
- **Reland channelz v2tov1 features**
- **Rollback channelz v2tov1 related changes due to multiple breakages**
- **[Python] Make protoc_test work python > 3.7 on macos, windows (#40253)**
- **[sanity] Fix (#40286)**
- **[PH2][Settings][Validations] Adding validations and unit tests for them (#40245)**
- **[Python] Fix/Upgarde Typeguard version (#40280)**
- **[PH2][Settings] Adding comments**
- **[Python] Fix bazel tests compatibility with python 3.11 (#40273)**
- **[Doc] Updated "Updating third_party/protobuf" (#40294)**
- **[latent_see] Add always on latent-see, and a service to drive it (#39781)**
- **Automated rollback of commit a9796dbe6f9e1819a5a97aa626c6ec375e15ed13.**
- **[Build] Clean obsolete configs (#40299)**
- **[Fix][Sanity] Fix master (#40305)**
- **[Python][Typeguard] Part 2 - Add Typeguard to AIO stack in tests  (#40215)**
- **[Bazel] Updated the maintainers of BCR (#40303)**
- **Spiffe xds (#40279)**
- **[stats] Create utils to port stats generation into C++ from python.**
- **[CI] Use python 3.9+ everywhere (#40139)**
- **Add additional logging to secure endpoint.**
- **[Python][Part 6] - Introducing Ruff (#40181)**
- **[channelz] Rendering improvements for v2 entities**
- **[Python][Typeguard] Part 3 - Add Typeguard to AIO stack in tests (#40217)**
- **[Python][Part 3] - Introducing Ruff (#40172)**
- **[CI] Added 1.74 to C++, Python, Ruby, and PHP (#40322)**
- **[interop] Add v1.74.2 release of grpc-go to interop matrix (#40287)**
- **[Sanity] Fix (#40328)**
- **Reland  https://github.com/grpc/grpc/pull/40179**
- **Reland https://github.com/grpc/grpc/pull/40231**
- **Log error when null creds are returned**
- **[event_engine] PosixEventEngine cleanups. (#40296)**
- **[OTel C++] Implement retry metrics (#39195)**
- **[Fix] LOG(FATAL) instead of CHECK_EQ (#40333)**
- **[PH2] Fix Half Closed Remote Stream State Validation**
- **[PH2] StreamQ Enqueue operations (#40240)**
- **[PH2] Disabling some E2E tests for PH2**
- **[PH2][Settings] Security frame checking**
- **[interop] Add grpc-java 1.73.0 to client_matrix.py (#39677)**
- **[PH2] Remove locks from SimpleQueue (#40343)**
- **[PH2] Disabling some E2E tests for PH2**
- **[Python][Part 4] - Introducing Ruff (#40173)**
- **[Python] Change typing extensions version to 4.12.2 (#40331)**
- **[Python][Part 5] - Introducing Ruff (#40180)**
- **[PH2][Settings] Initialize settings (#40342)**
- **[readme] Restore WORKSPACE section (#40348)**
- **Add `#include <memory>` to BoringSSL headers to make them work with Windows SDK.**
- **[Filter Fusion] Ensure fused filters always instantiate an error interceptor latch in promise_based_filter**
- **[PH2] Disabling some E2E tests for PH2**
- **Integrate memory quota with channelz**
- **[cf_engine] Fix compiler error (#40357)**
- **[Python] Fixes issue 40325 (#40347)**
- **Experimental: Create Gemini files for every directory in gRPC Core.**
- **[sigh] Sanity Fix (#40365)**
- **[ObjC] cfsocket listener implementation (#40097)**
- **[PH2][Settings] Adding comments**
- **[PH2][Trivial] Naming This is a very well written test suite. Which is why we (and Gemini) copy paste from it always. Removing misleading naming because this gets copy pasted often.**
- **[PH2][StreamQ] Dequeue Operations (#40345)**
- **[owners] reduce scope in owners for apolcyn (#39768)**
- **Create a standard config `:grpc_small_clients` for binary-size sensitive clients. This includes Android, iOS, and a newly-introduced opt-in flag --//:small_clients.**
- **[PH2]  Simplify metadata helper function (#40370)**
- **[codegen] Fix interesting spelling of Shift 💩**
- **[telemetry] Prepare to introduce Concrete Types For Call Tracers**
- **[PH2][StreamQ] Add a few DCHECKs in the dequeue functions. (#40369)**
- **wrapping ares.h dependency with GRPC_ARES == 1 preprocessor guards (#40391)**
- **[Copybara] Making includes uniform . This is for build layering (#40388)**
- **[experiments] Update expiry of local_connector_secure experiment. (#40386)**
- **[gemini] Add a note on arenas**
- **[experiments] Update fork experiment expiry (#40392)**
- **Ruby: Mark credential object in channel (#40394)**
- **[PH2][StreamQ] Track writable state in streamQ (#40385)**
- **[Settings][Trivial]  (#40401)**
- **[PH2] List Of Writable Streams (#40374)**
- **Begin moving gRPC socket_mutator files out of the iomgr folder**
- **Disable load balancer policies other than pick_first if --//:minimal_lb_policy is set.**
- **[tracing] Don't add a null TcpCallTracer from StartNewTcpTrace()**
- **Mark Fuchsia OS as a gRPC small client for binary size optimization. Add an opt-out flag `--//:exclude_small_client`.**
- **[Security][XDS] Support Verification with SPIFFE Bundle Maps (#40321)**
- **[telemetry] Instrument library**
- **[Python] Update musllinux release artifacts from musllinux_1_1 to musllinux_1_2 (#40317)**
- **[Python] Update manylinux and armv7 docker images (#40383)**
- **Automated rollback of commit 416d9c9693349cd8fb15e1b91e0d34919c32893d.**
- **[PH2][Settings] Adding helper function**
- **Fixing a crash in #36415**
- **sanity: update dockerimage_current_versions.bzl (#40429)**
- **[PSM Interop] Legacy driver: freeze pip deps (#40438)**
- **[posix_engine] Remove PosixPollerManager (#40356)**
- **Revert "[Security][XDS] Support Verification with SPIFFE Bundle Maps … (#40445)**
- **[OTel C++] Add a null-check to the text map propagator.**
- **Automated rollback of commit 303b395b9780e1ff0939a576efe14b5b168c8d40.**
- **[gemini] Document gRPC Core's coding style regarding exceptions.**
- **[PH2][Settings] Setting max_header_list_size max_header_list_size is set only once in both CHTTP2 and PH2. So we set it once and enforce it in the HeaderAssembler when we receive frames.**
- **[PH2][Settings] Adding documentation**
- **[PH2] WritePath Integration (#40404)**
- **Bump core version to 50.0.0 for upcoming release (#40422)**
- **[telemetry] Histograms for new telemetry collection system**
- **[channelz] Add support for rendering lists of entities**
- **[PH2][Settings] Settings Timeout (#40406)**
- **[PH2] Refactor Write Loop (#40441)**
- **[PH2] Flow Control includes (#40458)**
- **[PH2][Settings] Plumbing custom gRPC setting "Use True Binary Metadata"**
- **Update gmock include paths in gRPC tests.**
- **[build] Add Missing Dependencies for filter_test in Preparation for Enabling layering_check**
- **[build] Add Missing Dependencies for end2end_test_lib, proxy, http_proxy, cq_verifier, batch_builder, grpc_test_util_unsecure, test_call_creds in Preparation for Enabling layering_check**
- **Float the LegacyMaxAgeFilter to the top of the stack to allow for better fusions.**
- **[Python] gRPC AsyncIO: Improve CompletionQueue polling performance (#39993)**
- **[Python] Allow local builds to skip _grpcio_metadata.py regeneration (#40436)**
- **[Security] Spiffe Verification roll forward (#40476)**
- **[Python] macOS build: fix unused-command-line-argument -stdlib=libc++ (#40446)**
- **Migrate Resource Quota telemetry to a dedicated InstrumentDomain.**
- **[priority LB] don't fake a report of TF when failover timer fires (#40453)**
- **[build] Add Missing Dependencies for oauth2_utils, timer, server, fake_stats_plugin, fail_first_call_filter, interceptors_util, test_util in Preparation for Enabling layering_check**
- **[build] Add Missing Dependencies for event_engine_test_framework, oracle_event_engine_posix, endpoint in Preparation for Enabling layering_check**
- **[PH2][Settings] Fixing TSAN Acquire `transport_mutex_` before processing received HTTP/2 SETTINGS. This ensures thread safety when validating and applying settings received from the server.**
- **[build] Add Missing Dependencies for test/core/compression in Preparation for Enabling layering_check**
- **[build] Add Missing Dependencies for test/core/credentials in Preparation for Enabling layering_check**
- **Automated rollback of commit 56976b0b3c2f75dd9e80cab65f948c5690c8726d.**
- **[build] Add Missing Dependencies for fuzzing_event_engine in Preparation for Enabling layering_check**
- **[build] Add Missing Dependencies for test/core/config in Preparation for Enabling layering_check**
- **[build] Add Missing Dependencies for gpr_platform in Preparation for Enabling layering_check**
- **[build] Add Missing Dependencies for grpc++_unsecure in Preparation for Enabling layering_check**
- **[build] Add Missing Dependencies for test/core/address_utils in Preparation for Enabling layering_check**
- **[build] Add Missing Dependencies for test/core/client_channel in Preparation for Enabling layering_check**
- **[build] Add Missing Dependencies for grpc_slice in Preparation for Enabling layering_check**
- **[build] Add Missing Dependencies for test/core/service_config, test/core/ext/filters/rbac, test/core/resource_quota in Preparation for Enabling layering_check**
- **[build] Add Missing Dependencies for event_engine_base_hdrs in Preparation for Enabling layering_check**
- **[Sanity] Fix (#40490)**
- **[build] Add Missing Dependencies for test/core/util in Preparation for Enabling layering_check**
- **[build] Add Missing Dependencies for test/cpp/ext/filters, test/cpp/ext/gcp, test/cpp/ext/otel in Preparation for Enabling layering_check**
- **[build] Add Missing Dependencies for test/core/transport in Preparation for Enabling layering_check**
- **[build] Add Missing Dependencies for test/cpp/test, test/cpp/security, test/cpp/grpclb, test/cpp/performance in Preparation for Enabling layering_check**
- **[build] Add Missing Dependencies for grpc_cli_utils in Preparation for Enabling layering_check**
- **[metrics] add grpc.lb.backend_service label (#40486)**
- **[sanity] fix master (#40502)**
- **[PH2][StreamQ] Adding priority for streams (#40456)**
- **[build] Add Missing Dependencies for security_connector_test, xds_credentials_test, fuzzing_common, api_fuzzer, network_input, client_fuzzer, server_fuzzer, connector_fuzzer in Preparation for Enabling layering_check**
- **[build] Add Missing Dependencies for bm_client_call, call_spine_benchmarks, bm_call_spine, bad_ssl_test_server, bad_ssl_%s_server, close_fd_test in Preparation for Enabling layering_check**
- **[PH2][Util] Add variant support to MemoryUsageOf (#40487)**
- **[build] Add Missing Dependencies for test/core/resolver, test/core/security, test/core/server, test/core/slice, test/core/surface in Preparation for Enabling layering_check**
- **[build] Add Missing Dependencies for thread_pool_test, default_engine_methods_test, tcp_socket_utils_test, basic_work_queue_fuzzer, bm_experiments, resolver_fuzzer, filter_test_test, gcp_authentication_filter_test, bm_http_client_filter, test_handshake, handshaker_fuzzer in Preparation for Enabling layering_check**
- **[build] Add Missing Dependencies for posix_engine_test_utils, lock_free_event_test, wakeup_fd_posix_test, traced_buffer_list_test, tcp_posix_socket_utils_test, posix_endpoint_test, posix_engine_listener_utils_test, posix_event_engine_connect_test, log_too_many_open_files_test, windows_event_engine_test, oracle_event_engine_posix_test, dns, client, windows_event_engine_echo_client, posix_event_engine_echo_client, echo_client, fake_udp_and_tcp_server in Preparation for Enabling layering_check**
- **[build] Add Missing Dependencies for test/core/xds in Preparation for Enabling layering_check**
- **[build] Add Missing Dependencies for test/core/tsi/alts/fake_handshaker, test/core/tsi/alts/frame_protector, test/core/tsi/alts/handshaker in Preparation for Enabling layering_check**
- **[build] Add Missing Dependencies for grpcpp_status, generic_stub_internal, grpc++_codegen_proto, grpc++_base in Preparation for Enabling layering_check**
- **[build] Add Missing Dependencies for test/core/load_balancing in Preparation for Enabling layering_check**
- **[build] Add Missing Dependencies for grpc_objective_c_plugin in Preparation for Enabling layering_check**
- **[build] Add Missing Dependencies for test/cpp/interop, test/cpp/server, test/cpp/thread_manager, test/cpp/util in Preparation for Enabling layering_check**
- **Fix Failures**
- **[sanity] fix on master (#40518)**
- **ALTS Integrity-only negotiation**




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

